### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,10 +47,7 @@
   "engines": {
     "node": ">=0.10.0"
   },
-  "license": {
-    "type": "unlicence",
-    "url": "http://unlicense.org"
-  },
+  "license": "Unlicence",
   "scripts": {
     "rebuild": "rm -rf node_modules && npm install",
     "test": "grunt test"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license