### PR TITLE
update sassdoc dependency to 2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "dependencies": {
     "lodash.assign": "^4.0.3",
-    "sassdoc": "^2.0.0"
+    "sassdoc": "^2.5.0"
   },
   "devDependencies": {
     "grunt": "^1.0.1",


### PR DESCRIPTION
grunt-sassdoc requires sassdoc; sassdoc requires sassdoc-theme-default; sassdoc-theme-default requires sassdoc-extras; sassdoc-extras requires marked. The current versions import marked 0.3.7, which is vulnerable.

The current version of grunt-sassdoc only requires sassdoc 2.0.0; this requires sassdoc 2.5.0.
* sassdoc 2.5.0 requires sassdoc-theme-default ^2.6.1
* sassdoc-theme-default 2.6.1 requires sassdoc-extras ^2.4.0
* sassdoc-extras requires marked ^0.3.9